### PR TITLE
Ensure single withdrawal bill per employee

### DIFF
--- a/lib/models/Sale.ts
+++ b/lib/models/Sale.ts
@@ -167,6 +167,11 @@ SaleSchema.index({ employeeId: 1 })
 SaleSchema.index({ saleDate: -1 })
 SaleSchema.index({ type: 1 })
 SaleSchema.index({ employeeId: 1, saleDate: -1 })
+// Ensure only one open withdrawal bill per employee
+SaleSchema.index(
+  { employeeId: 1, type: 1, settled: 1 },
+  { unique: true, partialFilterExpression: { type: 'เบิก', settled: false } }
+)
 
 // Pre-save middleware to calculate total amount
 SaleSchema.pre('save', function(next) {


### PR DESCRIPTION
## Summary
- Prevent multiple open withdrawal bills per employee by reusing existing bill when adding items
- Enforce uniqueness of open withdrawal bill per employee at the database level

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4355a18d48325ba75bef58e2bea27