### PR TITLE
refactor dynamic API routes to await params

### DIFF
--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -7,8 +7,9 @@ import { getUserFromRequest } from '../../../../../lib/auth'
 // GET - Get specific product
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   try {
     const currentUser = getUserFromRequest(request)
     
@@ -20,8 +21,6 @@ export async function GET(
     }
     
     await connectDB()
-    
-    const { id } = params
     
     const product = await Product.findById(id).lean()
     
@@ -46,8 +45,9 @@ export async function GET(
 // PUT - Update product (admin only)
 export async function PUT(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   try {
     const currentUser = getUserFromRequest(request)
     
@@ -59,8 +59,6 @@ export async function PUT(
     }
     
     await connectDB()
-    
-    const { id } = params
     const { name, prices, category } = await request.json()
     
     const product = await Product.findById(id)
@@ -139,8 +137,9 @@ export async function PUT(
 // DELETE - Delete product (admin only)
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   try {
     const currentUser = getUserFromRequest(request)
     
@@ -152,8 +151,6 @@ export async function DELETE(
     }
     
     await connectDB()
-    
-    const { id } = params
     
     const updatedProduct = await Product.findByIdAndUpdate(
       id,

--- a/src/app/api/requisitions/[id]/clear/route.ts
+++ b/src/app/api/requisitions/[id]/clear/route.ts
@@ -5,8 +5,9 @@ import { getUserFromRequest } from '../../../../../../lib/auth'
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   try {
     const currentUser = getUserFromRequest(request)
     if (!currentUser) {
@@ -14,7 +15,6 @@ export async function POST(
     }
 
     await connectDB()
-    const { id } = params
     const requisition = await Requisition.findOne({ _id: id, employeeId: currentUser._id, status: 'open' })
 
     if (!requisition) {

--- a/src/app/api/sales/[id]/route.ts
+++ b/src/app/api/sales/[id]/route.ts
@@ -6,7 +6,11 @@ import User from '../../../../../lib/models/User'
 import { getUserFromRequest } from '../../../../../lib/auth'
 import mongoose from 'mongoose'
 
-export async function DELETE(request: NextRequest, { params }: { params: { id: string } }) {
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: saleId } = await params
   try {
     const currentUser = getUserFromRequest(request)
     if (!currentUser || currentUser.role !== 'admin') {
@@ -14,8 +18,6 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
     }
 
     await connectDB()
-
-    const saleId = params.id
 
     const session = await mongoose.startSession()
     session.startTransaction()
@@ -47,7 +49,11 @@ export async function DELETE(request: NextRequest, { params }: { params: { id: s
 }
 
 // PUT - Update existing sale
-export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: saleId } = await params
   try {
     const currentUser = getUserFromRequest(request)
     if (!currentUser) {
@@ -55,8 +61,6 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
     }
 
     await connectDB()
-
-    const saleId = params.id
     const {
       items,
       notes,

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -6,8 +6,9 @@ import { getUserFromRequest, hashPassword } from '../../../../../lib/auth'
 // GET - Get specific user
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   try {
     const currentUser = getUserFromRequest(request)
     
@@ -19,8 +20,6 @@ export async function GET(
     }
     
     await connectDB()
-    
-    const { id } = params
     
     // Check if user can access this data
     if (currentUser.role !== 'admin' && currentUser.userId !== id) {
@@ -55,8 +54,9 @@ export async function GET(
 // PUT - Update user
 export async function PUT(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   try {
     const currentUser = getUserFromRequest(request)
     
@@ -68,8 +68,6 @@ export async function PUT(
     }
     
     await connectDB()
-    
-    const { id } = params
     const updateData = await request.json()
     
     // Check if user can update this data
@@ -165,8 +163,9 @@ export async function PUT(
 // DELETE - Delete user (admin only)
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: Promise<{ id: string }> }
 ) {
+  const { id } = await params
   try {
     const currentUser = getUserFromRequest(request)
     
@@ -178,8 +177,6 @@ export async function DELETE(
     }
     
     await connectDB()
-    
-    const { id } = params
     
     // Prevent admin from deleting themselves
     if (currentUser.userId === id) {


### PR DESCRIPTION
## Summary
- refactor product, user, sale, and requisition API routes to await dynamic route params before use

## Testing
- `npm run build` *(fails: Failed to fetch `Geist` fonts; Build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a44bbac30c83258a8a45311f8053f6