### PR TITLE
Fix product search limit for withdrawals

### DIFF
--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -95,7 +95,8 @@ export default function SalesPage() {
     try {
       const [salesRes, productsRes, employeesRes] = await Promise.all([
         fetch(`/api/sales?page=${page}&limit=${limit}`, { credentials: 'include' }),
-        fetch('/api/products', { credentials: 'include' }),
+        // Fetch all products to ensure search can find every item
+        fetch('/api/products?limit=1000', { credentials: 'include' }),
         fetch('/api/users', { credentials: 'include' })
       ])
 


### PR DESCRIPTION
## Summary
- fetch all products in sales page to allow complete product search

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a45a4866b483259193929e5d7312d0