### PR TITLE
feat(ui): add loading spinner to save buttons

### DIFF
--- a/src/app/employees/page.tsx
+++ b/src/app/employees/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from 'react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Layout from '@/components/Layout'
 import Pagination from '@/components/Pagination'
+import Button from '@/components/Button'
 import toast from 'react-hot-toast';
 
 interface Employee {
@@ -30,6 +31,7 @@ export default function EmployeesPage() {
   const [total, setTotal] = useState(0)
   const [showModal, setShowModal] = useState(false)
   const [editingEmployee, setEditingEmployee] = useState<Employee | null>(null)
+  const [submitting, setSubmitting] = useState(false)
   const [formData, setFormData] = useState({
     username: '',
     email: '',
@@ -68,11 +70,11 @@ export default function EmployeesPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    
+    setSubmitting(true)
     try {
       const url = editingEmployee ? `/api/users/${editingEmployee._id}` : '/api/users'
       const method = editingEmployee ? 'PUT' : 'POST'
-      
+
       const submitData: Record<string, unknown> = {
         username: formData.username,
         email: formData.email,
@@ -86,7 +88,7 @@ export default function EmployeesPage() {
       if (formData.password) {
         submitData.password = formData.password
       }
-      
+
       const response = await fetch(url, {
         method,
         headers: {
@@ -108,6 +110,8 @@ export default function EmployeesPage() {
     } catch (error) {
       console.error('Submit error:', error)
       toast.error('An error occurred while saving employee data.')
+    } finally {
+      setSubmitting(false)
     }
   }
 
@@ -370,12 +374,13 @@ export default function EmployeesPage() {
                       >
                         ยกเลิก
                       </button>
-                      <button
+                      <Button
                         type="submit"
-                        className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+                        isLoading={submitting}
+                        className="px-4 py-2 text-sm"
                       >
                         {editingEmployee ? 'บันทึกการแก้ไข' : 'เพิ่มพนักงาน'}
-                      </button>
+                      </Button>
                     </div>
                   </form>
                 </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -83,7 +83,7 @@ export default function LoginPage() {
 
             <Button
               type="submit"
-              disabled={loading}
+              isLoading={loading}
               className="w-full py-3"
             >
               {loading ? 'กำลังเข้าสู่ระบบ...' : 'เข้าสู่ระบบ'}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import ProtectedRoute from '@/components/ProtectedRoute'
 import Layout from '@/components/Layout'
+import Button from '@/components/Button'
 import { useAuth } from '@/contexts/AuthContext'
 
 export default function ProfilePage() {
@@ -215,13 +216,13 @@ export default function ProfilePage() {
               </div>
 
               <div className="flex justify-end pt-6 border-t border-gray-200">
-                <button
+                <Button
                   type="submit"
-                  disabled={loading}
-                  className="px-6 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  isLoading={loading}
+                  className="px-6 py-2 text-sm"
                 >
                   {loading ? 'กำลังบันทึก...' : 'บันทึกการเปลี่ยนแปลง'}
-                </button>
+                </Button>
               </div>
             </form>
           </div>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,14 +2,19 @@ import React from 'react'
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'danger'
+  isLoading?: boolean
 }
 
 const Button: React.FC<ButtonProps> = ({
   variant = 'primary',
+  isLoading = false,
   className = '',
+  disabled,
+  children,
   ...props
 }) => {
-  const baseStyles = 'px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed'
+  const baseStyles =
+    'px-4 py-2 rounded-lg font-medium transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed'
   const variants: Record<string, string> = {
     primary:
       'bg-gradient-to-r from-blue-600 to-indigo-600 text-white hover:from-blue-500 hover:to-indigo-500 focus:ring-blue-500',
@@ -19,7 +24,19 @@ const Button: React.FC<ButtonProps> = ({
       'bg-gradient-to-r from-red-600 to-pink-600 text-white hover:from-red-500 hover:to-pink-500 focus:ring-red-500'
   }
 
-  return <button className={`${baseStyles} ${variants[variant]} ${className}`} {...props} />
+  return (
+    <button
+      className={`${baseStyles} ${variants[variant]} ${className}`}
+      disabled={isLoading || disabled}
+      {...props}
+    >
+      {isLoading && (
+        <span className="inline-block w-4 h-4 mr-2 border-2 border-white border-t-transparent rounded-full animate-spin" />
+      )}
+      {children}
+    </button>
+  )
 }
 
 export default Button
+


### PR DESCRIPTION
## Summary
- add optional loading state with spinner to Button component
- show saving animation on profile and employee forms
- display spinner on login button during authentication

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a84450a88325a190e79164eac9e6