### PR TITLE
feat(ui): animate save buttons

### DIFF
--- a/src/app/employees/page.tsx
+++ b/src/app/employees/page.tsx
@@ -377,7 +377,7 @@ export default function EmployeesPage() {
                       <Button
                         type="submit"
                         isLoading={submitting}
-                        className="px-4 py-2 text-sm"
+                        className="px-4 py-2 text-sm transform hover:scale-105 active:scale-95"
                       >
                         {editingEmployee ? 'บันทึกการแก้ไข' : 'เพิ่มพนักงาน'}
                       </Button>

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -338,7 +338,7 @@ export default function ProductsPage() {
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
                           <button
                             onClick={() => handleSubmit()}
-                            className="text-green-600 hover:text-green-900"
+                            className="text-green-600 hover:text-green-900 transform transition-all hover:scale-105 active:scale-95"
                             type="button"
                           >
                             บันทึก
@@ -453,7 +453,7 @@ export default function ProductsPage() {
                       </button>
                       <button
                         type="submit"
-                        className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+                        className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transform transition-all hover:scale-105 active:scale-95"
                       >
                         {editingProduct ? 'บันทึกการแก้ไข' : 'เพิ่มสินค้า'}
                       </button>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -219,7 +219,7 @@ export default function ProfilePage() {
                 <Button
                   type="submit"
                   isLoading={loading}
-                  className="px-6 py-2 text-sm"
+                  className="px-6 py-2 text-sm transform hover:scale-105 active:scale-95"
                 >
                   {loading ? 'กำลังบันทึก...' : 'บันทึกการเปลี่ยนแปลง'}
                 </Button>

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -622,7 +622,7 @@ export default function SalesPage() {
                       </button>
                       <button
                         type="submit"
-                        className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transition-colors"
+                        className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transform transition-all hover:scale-105 active:scale-95"
                       >
                         {editingSaleId ? 'บันทึกการเปลี่ยนแปลง' : 'บันทึกการเบิก'}
                       </button>

--- a/src/app/settlement/page.tsx
+++ b/src/app/settlement/page.tsx
@@ -399,7 +399,7 @@ export default function SettlementPage() {
                     </button>
                     <button
                       type="submit"
-                      className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md"
+                      className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transform transition-all hover:scale-105 active:scale-95"
                     >
                       บันทึก
                     </button>


### PR DESCRIPTION
## Summary
- add scale animations to product edit and modal save actions
- animate save buttons in employee, sales, settlement, and profile pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ab0009fc8325a6b59b89d0bf739c