### PR TITLE
feat(ui): show saving animation on sales and settlement

### DIFF
--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -6,6 +6,7 @@ import Layout from '@/components/Layout'
 import Pagination from '@/components/Pagination'
 import { useAuth } from '@/contexts/AuthContext'
 import toast from 'react-hot-toast';
+import Button from '@/components/Button'
 
 interface Price {
   level: string;
@@ -68,6 +69,7 @@ export default function SalesPage() {
   const [selectedProductIndex, setSelectedProductIndex] = useState(-1)
   const [detailSale, setDetailSale] = useState<Sale | null>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const [formData, setFormData] = useState({
     employeeId: '',
@@ -172,7 +174,8 @@ export default function SalesPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    
+    setIsSubmitting(true)
+
     try {
       const processedItems = formData.items.map(item => ({
         productId: item.productId,
@@ -212,6 +215,8 @@ export default function SalesPage() {
     } catch (error) {
       console.error('Submit error:', error)
       toast.error('เกิดข้อผิดพลาดในการบันทึกข้อมูล')
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -620,12 +625,13 @@ export default function SalesPage() {
                       >
                         ยกเลิก
                       </button>
-                      <button
+                      <Button
                         type="submit"
+                        isLoading={isSubmitting}
                         className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transform transition-all hover:scale-105 active:scale-95"
                       >
                         {editingSaleId ? 'บันทึกการเปลี่ยนแปลง' : 'บันทึกการเบิก'}
-                      </button>
+                      </Button>
                     </div>
                   </form>
                 </div>

--- a/src/app/settlement/page.tsx
+++ b/src/app/settlement/page.tsx
@@ -7,6 +7,7 @@ import Pagination from '@/components/Pagination'
 import { useAuth } from '@/contexts/AuthContext'
 import toast from 'react-hot-toast'
 import { CATEGORY_TYPES, CategoryType } from '../../../lib/constants'
+import Button from '@/components/Button'
 
 interface SaleItem {
   productId: string
@@ -49,6 +50,7 @@ export default function SettlementPage() {
   const [itemsForm, setItemsForm] = useState<SaleItem[]>([])
   const [deliveredAmount, setDeliveredAmount] = useState('')
   const [categorySummary, setCategorySummary] = useState({ main: 0, optional: 0 })
+  const [isSubmitting, setIsSubmitting] = useState(false)
 
   const fetchSales = useCallback(async () => {
     try {
@@ -136,6 +138,7 @@ export default function SettlementPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!selectedSale) return
+    setIsSubmitting(true)
     try {
       const response = await fetch(`/api/sales/${selectedSale._id}`, {
         method: 'PUT',
@@ -170,6 +173,8 @@ export default function SettlementPage() {
     } catch (error) {
       console.error('Settle error:', error)
       toast.error('เกิดข้อผิดพลาด')
+    } finally {
+      setIsSubmitting(false)
     }
   }
 
@@ -397,12 +402,13 @@ export default function SettlementPage() {
                     >
                       ยกเลิก
                     </button>
-                    <button
+                    <Button
                       type="submit"
+                      isLoading={isSubmitting}
                       className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-md transform transition-all hover:scale-105 active:scale-95"
                     >
                       บันทึก
-                    </button>
+                    </Button>
                   </div>
                 </form>
               </div>


### PR DESCRIPTION
## Summary
- show loading spinner while saving sales
- show loading spinner while saving settlements

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a522a39c788325a9fdaf14d6f2ce12