### PR TITLE
feat(dashboard): add monthly sales summary

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -18,6 +18,8 @@ interface DashboardData {
     totalEmployees: number
     todaySalesAmount: number
     todaySalesCount: number
+    monthlySalesAmount: number
+    monthlySalesCount: number
     totalSalesAmount: number
     totalSalesCount: number
   }
@@ -90,7 +92,7 @@ export default function DashboardPage() {
           </div>
 
           {/* Summary Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-6">
             <div className="bg-white rounded-lg shadow p-6">
               <div className="flex items-center">
                 <div className="flex-shrink-0">
@@ -126,6 +128,21 @@ export default function DashboardPage() {
                     {formatCurrency(data?.summary.todaySalesAmount || 0)}
                   </p>
                   <p className="text-sm text-gray-500">{data?.summary.todaySalesCount || 0} รายการ</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="bg-white rounded-lg shadow p-6">
+              <div className="flex items-center">
+                <div className="flex-shrink-0">
+                  <span className="text-2xl">🗓</span>
+                </div>
+                <div className="ml-4">
+                  <p className="text-sm font-medium text-gray-500">ยอดขายเดือนนี้</p>
+                  <p className="text-2xl font-semibold text-gray-900">
+                    {formatCurrency(data?.summary.monthlySalesAmount || 0)}
+                  </p>
+                  <p className="text-sm text-gray-500">{data?.summary.monthlySalesCount || 0} รายการ</p>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- include current month's sales in dashboard API
- display monthly sales amount and count in dashboard summary

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5866b6b5c8325a689ef189f57d18c