### PR TITLE
fix(products): include legacy products without isActive

### DIFF
--- a/src/app/api/products/[id]/route.ts
+++ b/src/app/api/products/[id]/route.ts
@@ -23,8 +23,8 @@ export async function GET(
     await connectDB()
     
     const product = await Product.findById<IProduct>(id).lean()
-    
-    if (!product || !product.isActive) {
+
+    if (!product || product.isActive === false) {
       return NextResponse.json(
         { error: 'Product not found' },
         { status: 404 }
@@ -75,7 +75,7 @@ export async function PUT(
     if (name !== undefined) {
       const existingProduct = await Product.findOne({
         name: { $regex: new RegExp(`^${name}$`, 'i') },
-        isActive: true,
+        isActive: { $ne: false },
         _id: { $ne: id }
       })
       

--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -24,7 +24,8 @@ export async function GET(request: NextRequest) {
     const skip = (page - 1) * limit
     const search = searchParams.get('search')?.toString().trim()
 
-    const query: Record<string, unknown> = { isActive: true }
+    // Include products that are active or don't have the isActive field (legacy data)
+    const query: Record<string, unknown> = { isActive: { $ne: false } }
     if (search) {
       query.name = { $regex: search, $options: 'i' }
     }
@@ -90,9 +91,9 @@ export async function POST(request: NextRequest) {
     }
     
     // Check if product name already exists
-    const existingProduct = await Product.findOne({ 
+    const existingProduct = await Product.findOne({
       name: { $regex: new RegExp(`^${name}$`, 'i') },
-      isActive: true
+      isActive: { $ne: false }
     })
     
     if (existingProduct) {


### PR DESCRIPTION
## Summary
- include legacy products missing `isActive` in product listings
- allow fetching and updating products without `isActive` flag

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type.)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7fc2db238832584b43d924326a072