### PR TITLE
fix(api): disable caching for dynamic data

### DIFF
--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -4,6 +4,10 @@ import Product from '../../../../lib/models/Product'
 import { CATEGORY_TYPES } from '../../../../lib/constants'
 import { getUserFromRequest } from '../../../../lib/auth'
 
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+export const fetchCache = 'force-no-store'
+
 // GET - Get all products
 export async function GET(request: NextRequest) {
   try {

--- a/src/app/api/sales/route.ts
+++ b/src/app/api/sales/route.ts
@@ -7,6 +7,10 @@ import { getUserFromRequest } from '../../../../lib/auth'
 import { calculateCreditForUser, buildCreditSummary } from '../../../../lib/credit'
 import mongoose from 'mongoose'
 
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+export const fetchCache = 'force-no-store'
+
 // GET - Get sales (admin sees all, employee sees only their own)
 export async function GET(request: NextRequest) {
   try {

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -47,7 +47,8 @@ export default function ProductsPage() {
     try {
       const searchQuery = searchTerm ? `&search=${encodeURIComponent(searchTerm)}` : ''
       const response = await fetch(`/api/products?page=${page}&limit=${limit}${searchQuery}`, {
-        credentials: 'include'
+        credentials: 'include',
+        cache: 'no-store'
       })
 
       if (response.ok) {
@@ -88,7 +89,8 @@ export default function ProductsPage() {
       const response = await fetch('/api/products/import', {
         method: 'POST',
         body: formData,
-        credentials: 'include'
+        credentials: 'include',
+        cache: 'no-store'
       })
       if (response.ok) {
         const data = await response.json()
@@ -133,7 +135,8 @@ export default function ProductsPage() {
           prices: processedPrices,
           category: formData.category
         }),
-        credentials: 'include'
+        credentials: 'include',
+        cache: 'no-store'
       })
 
       if (response.ok) {
@@ -186,7 +189,8 @@ export default function ProductsPage() {
     try {
       const response = await fetch(`/api/products/${productId}`, {
         method: 'DELETE',
-        credentials: 'include'
+        credentials: 'include',
+        cache: 'no-store'
       })
 
       if (response.ok) {

--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -87,7 +87,8 @@ export default function SalesPage() {
     
     try {
       const response = await fetch(`/api/users/${employeeId}/credit`, {
-        credentials: 'include'
+        credentials: 'include',
+        cache: 'no-store'
       })
       
       if (response.ok) {
@@ -109,9 +110,9 @@ export default function SalesPage() {
   const fetchData = useCallback(async () => {
     try {
       const [salesRes, productsRes, employeesRes] = await Promise.all([
-        fetch(`/api/sales?page=${page}&limit=${limit}`, { credentials: 'include' }),
-        fetch('/api/products?limit=1000', { credentials: 'include' }),
-        fetch('/api/users?view=dropdown&limit=1000', { credentials: 'include' })
+        fetch(`/api/sales?page=${page}&limit=${limit}`, { credentials: 'include', cache: 'no-store' }),
+        fetch('/api/products?limit=1000', { credentials: 'include', cache: 'no-store' }),
+        fetch('/api/users?view=dropdown&limit=1000', { credentials: 'include', cache: 'no-store' })
       ])
 
       if (salesRes.ok) {
@@ -205,7 +206,8 @@ export default function SalesPage() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(submitData),
-        credentials: 'include'
+        credentials: 'include',
+        cache: 'no-store'
       })
 
       if (response.ok) {
@@ -276,7 +278,8 @@ export default function SalesPage() {
       try {
         const response = await fetch(`/api/sales/${saleId}`, {
           method: 'DELETE',
-          credentials: 'include'
+          credentials: 'include',
+          cache: 'no-store'
         });
 
         if (response.ok) {


### PR DESCRIPTION
## Summary
- mark the products and sales API route handlers as fully dynamic to prevent any response caching
- force the client-side fetches on the product and withdrawal pages to bypass caches so new MongoDB writes appear immediately

## Testing
- npm run lint *(fails: repository already contains eslint "any" rule violations and unused symbol warnings outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68ce6dc2846483259139b842a05f3d49